### PR TITLE
Fix TypeError when setting port

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 from flask import Flask, request, abort
+import os
 
 from linebot import (
     LineBotApi, WebhookHandler
@@ -44,4 +45,4 @@ def handle_text_message(event):
 
 import os
 if __name__ == "__main__":
-    app.run(host='0.0.0.0',port=os.environ['PORT'])
+    app.run(host='0.0.0.0',port=int(os.environ['PORT']))


### PR DESCRIPTION
This fixes this error.
```
2017-12-09T22:07:21.547776+00:00 app[web.1]: TypeError: port must be an integer
2017-12-09T22:07:28.832284+00:00 heroku[web.1]: Process exited with status 1
2017-12-09T22:07:28.858831+00:00 heroku[web.1]: State changed from starting to crashed
2017-12-09T22:07:28.714498+00:00 app[web.1]: Traceback (most recent call last):
2017-12-09T22:07:28.714513+00:00 app[web.1]:   File "app.py", line 47, in <module>
2017-12-09T22:07:28.714518+00:00 app[web.1]:     app.run(host='0.0.0.0',port=os.environ['PORT'])
2017-12-09T22:07:28.714519+00:00 app[web.1]:   File "/app/.heroku/python/lib/python2.7/site-packages/flask/app.py", line 841, in run
2017-12-09T22:07:28.714837+00:00 app[web.1]:     run_simple(host, port, self, **options)
2017-12-09T22:07:28.714839+00:00 app[web.1]:   File "/app/.heroku/python/lib/python2.7/site-packages/werkzeug/serving.py", line 733, in run_simple
2017-12-09T22:07:28.714998+00:00 app[web.1]:     raise TypeError('port must be an integer')
2017-12-09T22:07:28.715041+00:00 app[web.1]: TypeError: port must be an integer
```

